### PR TITLE
added virtual destructor to InfoProvider class to quiet compiler warnings

### DIFF
--- a/include/opmonlib/InfoProvider.hpp
+++ b/include/opmonlib/InfoProvider.hpp
@@ -20,6 +20,8 @@ class InfoProvider
 public:
   virtual void gather_stats(opmonlib::InfoCollector& ic, int level) = 0;
 
+  virtual ~InfoProvider() = default;
+
 private:
 };
 


### PR DESCRIPTION
I noticed warnings when compiling the appfwk package...