### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/opmonlib/Issues.hpp
+++ b/include/opmonlib/Issues.hpp
@@ -10,6 +10,7 @@
 #define OPMONLIB_INCLUDE_OPMONLIB_ISSUES_HPP_
 
 #include <ers/Issue.hpp>
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include <string>
 
 namespace dunedaq {

--- a/include/opmonlib/Issues.hpp
+++ b/include/opmonlib/Issues.hpp
@@ -10,7 +10,7 @@
 #define OPMONLIB_INCLUDE_OPMONLIB_ISSUES_HPP_
 
 #include <ers/Issue.hpp>
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include <string>
 
 namespace dunedaq {

--- a/include/opmonlib/MonitorableObject.hpp
+++ b/include/opmonlib/MonitorableObject.hpp
@@ -14,6 +14,7 @@
 #include <opmonlib/opmon/monitoring_tree.pb.h>
 
 #include "confmodel/OpMonConf.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <google/protobuf/message.h>
 

--- a/include/opmonlib/MonitorableObject.hpp
+++ b/include/opmonlib/MonitorableObject.hpp
@@ -14,7 +14,7 @@
 #include <opmonlib/opmon/monitoring_tree.pb.h>
 
 #include "confmodel/OpMonConf.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <google/protobuf/message.h>
 

--- a/include/opmonlib/OpMonFacility.hpp
+++ b/include/opmonlib/OpMonFacility.hpp
@@ -14,6 +14,7 @@
 #include <cetlib/BasicPluginFactory.h>
 #include <cetlib/compiler_macros.h>
 #include "opmonlib/opmon_entry.pb.h"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <iostream>
 #include <memory>

--- a/include/opmonlib/OpMonFacility.hpp
+++ b/include/opmonlib/OpMonFacility.hpp
@@ -14,7 +14,7 @@
 #include <cetlib/BasicPluginFactory.h>
 #include <cetlib/compiler_macros.h>
 #include "opmonlib/opmon_entry.pb.h"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <iostream>
 #include <memory>

--- a/include/opmonlib/OpMonManager.hpp
+++ b/include/opmonlib/OpMonManager.hpp
@@ -16,7 +16,7 @@
 #include "opmonlib/Utils.hpp"
 
 #include "confmodel/OpMonConf.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 namespace dunedaq {
 

--- a/include/opmonlib/OpMonManager.hpp
+++ b/include/opmonlib/OpMonManager.hpp
@@ -16,6 +16,8 @@
 #include "opmonlib/Utils.hpp"
 
 #include "confmodel/OpMonConf.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+
 namespace dunedaq {
 
   ERS_DECLARE_ISSUE( opmonlib,

--- a/include/opmonlib/Utils.hpp
+++ b/include/opmonlib/Utils.hpp
@@ -17,7 +17,7 @@
 #include <google/protobuf/message.h>
 #include "opmonlib/opmon_entry.pb.h"
 #include "ers/ers.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <google/protobuf/util/time_util.h>
 

--- a/include/opmonlib/Utils.hpp
+++ b/include/opmonlib/Utils.hpp
@@ -17,6 +17,7 @@
 #include <google/protobuf/message.h>
 #include "opmonlib/opmon_entry.pb.h"
 #include "ers/ers.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <google/protobuf/util/time_util.h>
 

--- a/plugins/fileOpMonFacility.cpp
+++ b/plugins/fileOpMonFacility.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <thread>
 
-#include <logging/Logging.hpp>
+#include "logging/Logging.hpp"
 
 
 namespace dunedaq::opmonlib {

--- a/plugins/stdoutOpMonFacility.cpp
+++ b/plugins/stdoutOpMonFacility.cpp
@@ -6,7 +6,7 @@
  * received with this code.
  */
 
-#include <logging/Logging.hpp>
+#include "logging/Logging.hpp"
 #include "opmonlib/JSonOpMonFacility.hpp"
 
 #include <google/protobuf/util/json_util.h>

--- a/src/MonitorableObject.cpp
+++ b/src/MonitorableObject.cpp
@@ -9,7 +9,7 @@
 #include <NullOpMonFacility.hpp>
 #include <opmonlib/MonitorableObject.hpp>
 #include <opmonlib/Utils.hpp>
-#include <logging/Logging.hpp>
+#include "logging/Logging.hpp"
 
 #include <google/protobuf/util/time_util.h>
 

--- a/src/OpMonManager.cpp
+++ b/src/OpMonManager.cpp
@@ -9,7 +9,7 @@
 #include <chrono>
 
 #include <opmonlib/OpMonManager.hpp>
-#include <logging/Logging.hpp>
+#include "logging/Logging.hpp"
 
 using namespace dunedaq::opmonlib;
 


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)