### PR TITLE
Allow for different amount of whitespace between JSON objects

### DIFF
--- a/python/opmonlib/info_file_collator.py
+++ b/python/opmonlib/info_file_collator.py
@@ -23,8 +23,9 @@ def collate_info_files(
         while idx < len(text):
             res = jd.raw_decode(text, idx)
             jsons.append(res[0])
-            idx = res[1] + 2
-
+            idx = res[1]
+            while idx < len(text) and text[idx] != '{':
+                idx += 1
     data = {}
 
     for jsonobj in jsons:


### PR DESCRIPTION
This fixes info_file_collator.py for the Opmon files generated by _drunc_ controllers.