### PR TITLE
Modified the collate_info_python python function so that it can be used to return the collated data without writing it to disk

### DIFF
--- a/python/opmonlib/info_file_collator.py
+++ b/python/opmonlib/info_file_collator.py
@@ -4,6 +4,11 @@ import json
 import click
 from rich.console import Console
 
+# 26-Nov-2025, KAB: modified this function so that it can return the collated opmon data
+# without necessarily writing the data to a file on disk. This involved changing the
+# order of the function arguments so that we can provide defaults of None for the
+# console and output_file, and it included changes to the body of the function to skip
+# console printouts and file output, if needed.
 def collate_info_files(
     json_files: list, console: Console = None, output_file: click.File = None
 ) -> dict:
@@ -18,6 +23,11 @@ def collate_info_files(
     for jf in json_files:
         if console is not None:
             console.log(f"Reading info JSON file {jf.name}")
+        # 26-Nov-2025, KAB: it seems that the data type of the input "json_files" is different
+        # when this function is called from the info_file_collator script in this repo compared
+        # with when it is called with the list of opmon files generated in an integtest (from
+        # integrationtest/opmon_metric_checks.py). The following "if/else" block takes this
+        # difference into account.
         if "pathlib.PosixPath" in str(type(jf)):
             text = jf.read_text()
         else:

--- a/python/opmonlib/info_file_collator.py
+++ b/python/opmonlib/info_file_collator.py
@@ -4,21 +4,24 @@ import json
 import click
 from rich.console import Console
 
-
 def collate_info_files(
-    output_file: click.File, json_files: list, console: Console
-) -> None:
+    json_files: list, console: Console = None, output_file: click.File = None
+) -> dict:
     """Collate the json information into an output file."""
-    console.log(
-        "Reading specified JSON files and outputting collated value traces to %s",
-        output_file.name,
-    )
+    if console is not None and output_file is not None:
+        console.log(
+            f"Reading specified JSON files and outputting collated value traces to {output_file.name}"
+        )
 
     jsons = []
     jd = json.JSONDecoder()
     for jf in json_files:
-        console.log(f"Reading info JSON file {jf.name}")
-        text = jf.read()
+        if console is not None:
+            console.log(f"Reading info JSON file {jf.name}")
+        if "pathlib.PosixPath" in str(type(jf)):
+            text = jf.read_text()
+        else:
+            text = jf.read()
         idx = 0
         while idx < len(text):
             res = jd.raw_decode(text, idx)
@@ -73,6 +76,8 @@ def collate_info_files(
             for value in jsonobj["data"][datapoint]:
                 objref[datapoint][jsonobj["time"]] = jsonobj["data"][datapoint][value]
 
-    json.dump(data, output_file, indent=4, sort_keys=True)
-    console.log("Operation complete")
-    return
+    if output_file is not None:
+        json.dump(data, output_file, indent=4, sort_keys=True)
+    if console is not None:
+        console.log("Operation complete")
+    return data

--- a/scripts/info_file_collator
+++ b/scripts/info_file_collator
@@ -18,6 +18,9 @@ import click
 @click.argument('json_files', type=click.File('r'), nargs=-1)
 
 def cli(output_file, json_files):
+    # 26-Nov-2025, KAB: changed the order of the arguments that are passed to the
+    # collate_info_files function based on the changes that have been made to it to
+    # support None values for the console and output_file.
     collate_info_files(json_files, console, output_file)
 
 if __name__ == '__main__':

--- a/scripts/info_file_collator
+++ b/scripts/info_file_collator
@@ -18,7 +18,7 @@ import click
 @click.argument('json_files', type=click.File('r'), nargs=-1)
 
 def cli(output_file, json_files):
-    collate_info_files(output_file, json_files, console)
+    collate_info_files(json_files, console, output_file)
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
# Description

These changes are for `fddaq-v5.6.0`...

As part of adding the validation of opmon metrics to integtests (DUNE-DAQ/daq-deliverables#202), it was helpful to be able to re-use the existing `collate_info_files` function in this repo.  However, a few minor tweaks to that function were needed in order to make its re-use possible.  

This PR contains the changes that were needed.  These are the following:

- a reorganization of the arguments to the function so that the console to be used for status messages and the output disk file where results should be written are optional
- modifications to the body of the `collate_info_files` function to only print out status messages if a Console was specified and only write out the result of collating the metrics to a file if a file name was specified

To test these changes, I verified that the results of running the new version of `info_file_collator` on a set of info*.json files gives the same result as the old version.  For example,

- run one of the existing regression tests
- `cd /tmp/pytest-of-${USER}/pytest-current/runcurrent`
- `info_file_collator info*json`
- check the contents of opmon_collated.json

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.

