### PR TITLE
Removing requirement of having `monkafka` in a publishing address

### DIFF
--- a/python/opmonlib/utils.py
+++ b/python/opmonlib/utils.py
@@ -206,13 +206,6 @@ def parse_opmon_conf(
             path = ""
         log.debug("No OpMon path required for type 'stdout'.")
 
-    if opmon_type == "stream" and "monkafka" not in path:
-        msg = "OpMon 'stream' configuration must publish to kafka, exiting."
-        raise ValueError(msg) from None
-    if opmon_type != "stream" and "monkafka" in path:
-        msg = "To use kafka, the type must be set to stream."
-        raise ValueError(msg) from None
-
     bootstrap = None
     topic = None
     if opmon_type == "file" and not Path(path).parent.is_dir():


### PR DESCRIPTION
# Description
See issue #63 

The current implementation of opmonlib requires a `monkafka` string to be in the address, this PR removes this block.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

