### PR TITLE
Mroda/stop

### DIFF
--- a/include/opmonlib/OpMonManager.hpp
+++ b/include/opmonlib/OpMonManager.hpp
@@ -71,10 +71,13 @@ public:
   
   // data collecting loop
   void start_monitoring(); 
-  // The stop command is not necessary.
+  // The stop command is not necessary, although it is provided to facilitate complex object behaviour
   // The stop is invoked during the destruction of the thread
   // the method requires a valid configuration because the time period is taken from there
 
+  void stop_monitoring();
+  // on top of stopping the monitorin thread, this method will also join the thread
+  
   void set_opmon_conf( const confmodel::OpMonConf* c ) {
     m_cfg.store(c);
     set_opmon_level( m_cfg.load()->get_level() );

--- a/src/OpMonManager.cpp
+++ b/src/OpMonManager.cpp
@@ -49,13 +49,16 @@ void OpMonManager::run(std::stop_token stoken ) {
     
     std::this_thread::sleep_for(sleep_interval);
     auto time_span = std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() - last_collection_time);
+
+    if ( time_span < reporting_interval ) continue;
+
+    if ( stoken.stop_requested() ) break;
+      
+    last_collection_time = std::chrono::steady_clock::now();
+    publish( collect() );
+    // there is no catch here because collect is supposed to catch all possible exceptions
+    // In this way we should garantee the collection of metrics on the system
     
-    if ( time_span >= reporting_interval ) {
-      last_collection_time = std::chrono::steady_clock::now();
-      publish( collect() );
-      // there is no catch here because collect is supposed to catch all possible exceptions
-      // In this way we should garantee the collection of metrics on the system
-    }
   }
 
   TLOG() << "Exiting the monitoring thread";

--- a/src/OpMonManager.cpp
+++ b/src/OpMonManager.cpp
@@ -42,12 +42,16 @@ void OpMonManager::start_monitoring() {
 
 void OpMonManager::stop_monitoring() {
 
+  TLOG() << "Gracefully requesting the monitoring thread to stop";
+  
   m_thread.request_stop();
   m_thread.join();
 }
 
 void OpMonManager::run(std::stop_token stoken ) {
 
+  TLOG() << "Monitoring thread started";
+  
   auto sleep_interval = std::chrono::milliseconds(100);
   auto reporting_interval = m_cfg.load()->get_interval();  
   auto last_collection_time = std::chrono::steady_clock::now();

--- a/src/OpMonManager.cpp
+++ b/src/OpMonManager.cpp
@@ -38,7 +38,14 @@ void OpMonManager::start_monitoring() {
     ers::warning(ThreadNameTooLong(ERS_HERE, thread_name));
   }
 }
-  
+
+
+void OpMonManager::stop_monitoring() {
+
+  m_thread.request_stop();
+  m_thread.join();
+}
+
 void OpMonManager::run(std::stop_token stoken ) {
 
   auto sleep_interval = std::chrono::milliseconds(100);

--- a/test/config/opmon.data.xml
+++ b/test/config/opmon.data.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="ASCII"?>
+
+<!-- oks-data version 2.2 -->
+
+
+<!DOCTYPE oks-data [
+  <!ELEMENT oks-data (info, (include)?, (comments)?, (obj)+)>
+  <!ELEMENT info EMPTY>
+  <!ATTLIST info
+      name CDATA #IMPLIED
+      type CDATA #IMPLIED
+      num-of-items CDATA #REQUIRED
+      oks-format CDATA #FIXED "data"
+      oks-version CDATA #REQUIRED
+      created-by CDATA #IMPLIED
+      created-on CDATA #IMPLIED
+      creation-time CDATA #IMPLIED
+      last-modified-by CDATA #IMPLIED
+      last-modified-on CDATA #IMPLIED
+      last-modification-time CDATA #IMPLIED
+  >
+  <!ELEMENT include (file)*>
+  <!ELEMENT file EMPTY>
+  <!ATTLIST file
+      path CDATA #REQUIRED
+  >
+  <!ELEMENT comments (comment)*>
+  <!ELEMENT comment EMPTY>
+  <!ATTLIST comment
+      creation-time CDATA #REQUIRED
+      created-by CDATA #REQUIRED
+      created-on CDATA #REQUIRED
+      author CDATA #REQUIRED
+      text CDATA #REQUIRED
+  >
+  <!ELEMENT obj (attr | rel)*>
+  <!ATTLIST obj
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+  <!ELEMENT attr (data)*>
+  <!ATTLIST attr
+      name CDATA #REQUIRED
+      type (bool|s8|u8|s16|u16|s32|u32|s64|u64|float|double|date|time|string|uid|enum|class|-) "-"
+      val CDATA ""
+  >
+  <!ELEMENT data EMPTY>
+  <!ATTLIST data
+      val CDATA #REQUIRED
+  >
+  <!ELEMENT rel (ref)*>
+  <!ATTLIST rel
+      name CDATA #REQUIRED
+      class CDATA ""
+      id CDATA ""
+  >
+  <!ELEMENT ref EMPTY>
+  <!ATTLIST ref
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+]>
+
+<oks-data>
+
+<info name="" type="" num-of-items="11" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231110T143339" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20241010T181349"/>
+
+<include>
+ <file path="schema/confmodel/dunedaq.schema.xml"/>
+</include>
+
+<comments>
+ <comment creation-time="20240327T161636" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="Reformat"/>
+ <comment creation-time="20241009T203950" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="Add test queues"/>
+ <comment creation-time="20241010T170002" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="testt"/>
+</comments>
+
+<obj class="OpMonConf" id="test_conf">
+  <attr name="interval_s" type="u32" val=3 />
+</obj>
+
+</oks-data>

--- a/test/config/opmon.data.xml
+++ b/test/config/opmon.data.xml
@@ -76,7 +76,7 @@
 </comments>
 
 <obj class="OpMonConf" id="test_conf">
-  <attr name="interval_s" type="u32" val=3 />
+  <attr name="interval_s" type="u32" val="3" />
 </obj>
 
 </oks-data>

--- a/unittest/monitorable_object_test.cxx
+++ b/unittest/monitorable_object_test.cxx
@@ -6,6 +6,8 @@
  * received with this code.
  */
 
+#include "confmodel/OpMonConf.hpp"
+
 #include "opmonlib/opmon/test.pb.h"
 #include "opmonlib/MonitorableObject.hpp"
 #include "opmonlib/TestOpMonManager.hpp"
@@ -123,7 +125,23 @@ BOOST_FIXTURE_TEST_CASE( counters, my_fixture ) {
 }
 
 
+BOOST_FIXTURE_TEST_CASE( start_stop, my_fixture ) {
 
+  // there is no configuration, so the monitoring thread cannot start
+  BOOST_CHECK_THROW ( manager.start_monitoring(), dunedaq::opmonlib::MissingConfiguration );
+
+  auto confdb = std::make_shared<dunedaq::conffwk::Configuration>("oksconflibs:test/config/opmon.data.xml");
+
+  
+  dunedaq::confmodel::OpMonConf conf;
+  conf.set_interval_s(1);
+
+  manager.start_monitoring();
+  
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+  
+  BOOST_CHECK_NO_THROW( manager.stop_monitoring() );
+}
 
 
 

--- a/unittest/monitorable_object_test.cxx
+++ b/unittest/monitorable_object_test.cxx
@@ -130,12 +130,12 @@ BOOST_FIXTURE_TEST_CASE( start_stop, my_fixture ) {
   // there is no configuration, so the monitoring thread cannot start
   BOOST_CHECK_THROW ( manager.start_monitoring(), dunedaq::opmonlib::MissingConfiguration );
 
-  auto confdb = std::make_shared<dunedaq::conffwk::Configuration>("oksconflibs:test/config/opmon.data.xml");
+  auto db = std::make_shared<dunedaq::conffwk::Configuration>("oksconflibs:test/config/opmon.data.xml");
 
+  auto conf = db->get<dunedaq::confmodel::OpMonConf>("test_conf");
+
+  manager.set_opmon_conf(conf);
   
-  dunedaq::confmodel::OpMonConf conf;
-  conf.set_interval_s(1);
-
   manager.start_monitoring();
   
   std::this_thread::sleep_for(std::chrono::seconds(3));

--- a/unittest/monitorable_object_test.cxx
+++ b/unittest/monitorable_object_test.cxx
@@ -135,14 +135,40 @@ BOOST_FIXTURE_TEST_CASE( start_stop, my_fixture ) {
   auto conf = db->get<dunedaq::confmodel::OpMonConf>("test_conf");
 
   manager.set_opmon_conf(conf);
-  
-  manager.start_monitoring();
-  
-  std::this_thread::sleep_for(std::chrono::seconds(3));
-  
+
+  for ( int i = 0; i < 4; ++i ) {
+    manager.start_monitoring();
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    BOOST_CHECK_NO_THROW( manager.stop_monitoring() );
+  }
+
+  // finally let's check we can start multuiple monitoring threads and only one works
+  for ( int i = 0; i < 4; ++i ) {
+    manager.start_monitoring();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
   BOOST_CHECK_NO_THROW( manager.stop_monitoring() );
+
 }
 
+BOOST_FIXTURE_TEST_CASE( multiple_start, my_fixture ) {
+
+  auto db = std::make_shared<dunedaq::conffwk::Configuration>("oksconflibs:test/config/opmon.data.xml");
+
+  auto conf = db->get<dunedaq::confmodel::OpMonConf>("test_conf");
+
+  manager.set_opmon_conf(conf);
+
+  // what we are testing here is that the creation of a separate monitoring thread
+  // is actually forcing the previous one to top due to the jthread correct desctructor
+  
+  for ( int i = 0; i < 4; ++i ) {
+    manager.start_monitoring();
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+  }
+  BOOST_CHECK_NO_THROW( manager.stop_monitoring() );
+
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Description

The stop of the monitoring thread in appfwk::Application is bugged: at the stop the status of the application is garbled: a clear sign that the state container is already destroyed while the monitoring thread is still ongoing. 

A more organised stop is necessary. This PR provides it.

To test this, we can just check that the last opmon entry of an Application has non garbled state.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

