### PR TITLE
Cherry-picked the stop monitoring changes from the develop branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(opmonlib VERSION 2.1.5)
+project(opmonlib VERSION 2.1.6)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/opmonlib/OpMonManager.hpp
+++ b/include/opmonlib/OpMonManager.hpp
@@ -71,10 +71,13 @@ public:
   
   // data collecting loop
   void start_monitoring(); 
-  // The stop command is not necessary.
+  // The stop command is not necessary, although it is provided to facilitate complex object behaviour
   // The stop is invoked during the destruction of the thread
   // the method requires a valid configuration because the time period is taken from there
 
+  void stop_monitoring();
+  // on top of stopping the monitorin thread, this method will also join the thread
+  
   void set_opmon_conf( const confmodel::OpMonConf* c ) {
     m_cfg.store(c);
     set_opmon_level( m_cfg.load()->get_level() );

--- a/src/OpMonManager.cpp
+++ b/src/OpMonManager.cpp
@@ -38,9 +38,20 @@ void OpMonManager::start_monitoring() {
     ers::warning(ThreadNameTooLong(ERS_HERE, thread_name));
   }
 }
+
+
+void OpMonManager::stop_monitoring() {
+
+  TLOG() << "Gracefully requesting the monitoring thread to stop";
   
+  m_thread.request_stop();
+  m_thread.join();
+}
+
 void OpMonManager::run(std::stop_token stoken ) {
 
+  TLOG() << "Monitoring thread started";
+  
   auto sleep_interval = std::chrono::milliseconds(100);
   auto reporting_interval = m_cfg.load()->get_interval();  
   auto last_collection_time = std::chrono::steady_clock::now();
@@ -49,13 +60,16 @@ void OpMonManager::run(std::stop_token stoken ) {
     
     std::this_thread::sleep_for(sleep_interval);
     auto time_span = std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() - last_collection_time);
+
+    if ( time_span < reporting_interval ) continue;
+
+    if ( stoken.stop_requested() ) break;
+      
+    last_collection_time = std::chrono::steady_clock::now();
+    publish( collect() );
+    // there is no catch here because collect is supposed to catch all possible exceptions
+    // In this way we should garantee the collection of metrics on the system
     
-    if ( time_span >= reporting_interval ) {
-      last_collection_time = std::chrono::steady_clock::now();
-      publish( collect() );
-      // there is no catch here because collect is supposed to catch all possible exceptions
-      // In this way we should garantee the collection of metrics on the system
-    }
   }
 
   TLOG() << "Exiting the monitoring thread";

--- a/test/config/opmon.data.xml
+++ b/test/config/opmon.data.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="ASCII"?>
+
+<!-- oks-data version 2.2 -->
+
+
+<!DOCTYPE oks-data [
+  <!ELEMENT oks-data (info, (include)?, (comments)?, (obj)+)>
+  <!ELEMENT info EMPTY>
+  <!ATTLIST info
+      name CDATA #IMPLIED
+      type CDATA #IMPLIED
+      num-of-items CDATA #REQUIRED
+      oks-format CDATA #FIXED "data"
+      oks-version CDATA #REQUIRED
+      created-by CDATA #IMPLIED
+      created-on CDATA #IMPLIED
+      creation-time CDATA #IMPLIED
+      last-modified-by CDATA #IMPLIED
+      last-modified-on CDATA #IMPLIED
+      last-modification-time CDATA #IMPLIED
+  >
+  <!ELEMENT include (file)*>
+  <!ELEMENT file EMPTY>
+  <!ATTLIST file
+      path CDATA #REQUIRED
+  >
+  <!ELEMENT comments (comment)*>
+  <!ELEMENT comment EMPTY>
+  <!ATTLIST comment
+      creation-time CDATA #REQUIRED
+      created-by CDATA #REQUIRED
+      created-on CDATA #REQUIRED
+      author CDATA #REQUIRED
+      text CDATA #REQUIRED
+  >
+  <!ELEMENT obj (attr | rel)*>
+  <!ATTLIST obj
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+  <!ELEMENT attr (data)*>
+  <!ATTLIST attr
+      name CDATA #REQUIRED
+      type (bool|s8|u8|s16|u16|s32|u32|s64|u64|float|double|date|time|string|uid|enum|class|-) "-"
+      val CDATA ""
+  >
+  <!ELEMENT data EMPTY>
+  <!ATTLIST data
+      val CDATA #REQUIRED
+  >
+  <!ELEMENT rel (ref)*>
+  <!ATTLIST rel
+      name CDATA #REQUIRED
+      class CDATA ""
+      id CDATA ""
+  >
+  <!ELEMENT ref EMPTY>
+  <!ATTLIST ref
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+]>
+
+<oks-data>
+
+<info name="" type="" num-of-items="11" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231110T143339" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20241010T181349"/>
+
+<include>
+ <file path="schema/confmodel/dunedaq.schema.xml"/>
+</include>
+
+<comments>
+ <comment creation-time="20240327T161636" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="Reformat"/>
+ <comment creation-time="20241009T203950" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="Add test queues"/>
+ <comment creation-time="20241010T170002" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="testt"/>
+</comments>
+
+<obj class="OpMonConf" id="test_conf">
+  <attr name="interval_s" type="u32" val="3" />
+</obj>
+
+</oks-data>

--- a/unittest/monitorable_object_test.cxx
+++ b/unittest/monitorable_object_test.cxx
@@ -6,6 +6,8 @@
  * received with this code.
  */
 
+#include "confmodel/OpMonConf.hpp"
+
 #include "opmonlib/opmon/test.pb.h"
 #include "opmonlib/MonitorableObject.hpp"
 #include "opmonlib/TestOpMonManager.hpp"
@@ -123,8 +125,50 @@ BOOST_FIXTURE_TEST_CASE( counters, my_fixture ) {
 }
 
 
+BOOST_FIXTURE_TEST_CASE( start_stop, my_fixture ) {
 
+  // there is no configuration, so the monitoring thread cannot start
+  BOOST_CHECK_THROW ( manager.start_monitoring(), dunedaq::opmonlib::MissingConfiguration );
 
+  auto db = std::make_shared<dunedaq::conffwk::Configuration>("oksconflibs:test/config/opmon.data.xml");
+
+  auto conf = db->get<dunedaq::confmodel::OpMonConf>("test_conf");
+
+  manager.set_opmon_conf(conf);
+
+  for ( int i = 0; i < 4; ++i ) {
+    manager.start_monitoring();
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    BOOST_CHECK_NO_THROW( manager.stop_monitoring() );
+  }
+
+  // finally let's check we can start multuiple monitoring threads and only one works
+  for ( int i = 0; i < 4; ++i ) {
+    manager.start_monitoring();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+  BOOST_CHECK_NO_THROW( manager.stop_monitoring() );
+
+}
+
+BOOST_FIXTURE_TEST_CASE( multiple_start, my_fixture ) {
+
+  auto db = std::make_shared<dunedaq::conffwk::Configuration>("oksconflibs:test/config/opmon.data.xml");
+
+  auto conf = db->get<dunedaq::confmodel::OpMonConf>("test_conf");
+
+  manager.set_opmon_conf(conf);
+
+  // what we are testing here is that the creation of a separate monitoring thread
+  // is actually forcing the previous one to top due to the jthread correct desctructor
+  
+  for ( int i = 0; i < 4; ++i ) {
+    manager.start_monitoring();
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+  }
+  BOOST_CHECK_NO_THROW( manager.stop_monitoring() );
+
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION

# Description

Merged pull request #66 from DUNE-DAQ/mroda/stop.

These changes need to be merged before the correlated ones in DUNE-DAQ/appfwk#363.

Here are suggested testing instructions:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt fddaq-v5.6.0
dbt-create fddaq-v5.6.0-a9 ${DATE_PREFIX}FDv5.6.0Test_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDv5.6.0Test_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/appfwk.git -b kbiery/opmon_stop_for_patch
git clone https://github.com/DUNE-DAQ/opmonlib.git -b kbiery/opmon_stop_for_patch
git clone https://github.com/DUNE-DAQ/ipm.git -b coredaq-v5.6.0
git clone https://github.com/DUNE-DAQ/iomanager.git -b coredaq-v5.6.0
git clone https://github.com/DUNE-DAQ/dfmodules.git -b coredaq-v5.6.0
git clone https://github.com/DUNE-DAQ/hsilibs.git -b coredaq-v5.6.0
git clone https://github.com/DUNE-DAQ/trigger.git -b coredaq-v5.6.0
git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b fddaq-v5.6.0
git clone https://github.com/DUNE-DAQ/fdreadoutlibs.git -b fddaq-v5.6.0
git clone https://github.com/DUNE-DAQ/fdreadoutmodules.git -b fddaq-v5.6.0
cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -k minimal

# verify that there are not garbled strings using
# grep -A15 AppInfo /tmp/pytest-of-${USER}/pytest-current/runcurrent/info*.json | grep -A 1 '"state"' | grep '\\'

```
